### PR TITLE
Changes to build for ARM64

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.bat text eol=crlf
+*.sh text eol=lf

--- a/phases/13-libffi.sh
+++ b/phases/13-libffi.sh
@@ -27,22 +27,22 @@ echo "### Running configure"
 MSVCC="$PWD/msvcc.sh -g"
 if [ "$ARCH" == "x86" ]; then
   MSVCC="$MSVCC -m32"
-  TARGET=i686-pc-cygwin # cygwin suffix required for building DLL
+  FFI_TARGET=i686-pc-cygwin # cygwin suffix required for building DLL
 elif [ "$ARCH" == "x64" ]; then
   MSVCC="$MSVCC -m64"
-  TARGET=x86_64-pc-cygwin
+  FFI_TARGET=x86_64-pc-cygwin
 elif [ "$ARCH" == "arm64" ]; then
   MSVCC="$MSVCC -marm64"
-  TARGET=arm64-pc-cygwin
+  FFI_TARGET=arm64-pc-cygwin
 else
   echo Unknown ARCH: $ARCH && exit 1
 fi
 if [ "$BUILD_TYPE" == "Debug" ]; then
   MSVCC="$MSVCC -DUSE_DEBUG_RTL"
 fi
-rm -rf $TARGET
+rm -rf $FFI_TARGET
 ./configure \
-  --build=$TARGET --host=$TARGET \
+  --build=$FFI_TARGET --host=$FFI_TARGET \
   --prefix="$UNIX_INSTALL_PREFIX" \
   --disable-docs \
   CC="$MSVCC" CXX="$MSVCC" LD=link \

--- a/phases/18-libdispatch.bat
+++ b/phases/18-libdispatch.bat
@@ -3,7 +3,14 @@ setlocal
 
 set PROJECT=libdispatch
 set GITHUB_REPO=flexibits/apple-swift-corelibs-libdispatch
-set TAG=
+
+:: TODO: These are patches made for ARM a while ago. Rebase those onto latest
+::       (and potentially merge them?) so that arm64 is up-to-date
+if "%ARCH%"=="arm64" (
+  set TAG=inactive/arm
+) else (
+  set TAG=
+)
 
 :: load environment and prepare project
 call "%~dp0\..\scripts\common.bat" prepare_project || exit /b 1

--- a/phases/20-gnustep-make.sh
+++ b/phases/20-gnustep-make.sh
@@ -19,7 +19,9 @@ CONFIGURE_OPTS=
 if [ "$BUILD_TYPE" == "Debug" ]; then
   CONFIGURE_OPTS=--enable-debug-by-default
 fi
+
 ./configure \
+  --build=$TARGET --host=$TARGET \
   --host=$TARGET \
   --prefix="$UNIX_INSTALL_PREFIX" \
   --with-library-combo=ng-gnu-gnu \

--- a/phases/42-libpng.bat
+++ b/phases/42-libpng.bat
@@ -3,7 +3,7 @@ setlocal
 
 set PROJECT=libpng
 set GITHUB_REPO=glennrp/libpng
-set TAG=v1.6.39
+set TAG=v1.6.44
 
 :: load environment and prepare project
 call "%~dp0\..\scripts\common.bat" prepare_project || exit /b 1
@@ -19,6 +19,7 @@ cmake .. %CMAKE_OPTIONS% ^
   -D PNG_STATIC=OFF ^
   -D PNG_EXECUTABLES=OFF ^
   -D PNG_TESTS=OFF ^
+  -Wno-dev ^
   || exit /b 1
 
 echo.

--- a/phases/50-gnustep-gui.sh
+++ b/phases/50-gnustep-gui.sh
@@ -20,7 +20,7 @@ echo "### Loading GNUstep environment"
 echo
 echo "### Running configure"
 ./configure \
-  --host=$TARGET \
+  --build=$TARGET --host=$TARGET \
   `# specify environment since it doesn't use gnustep-config to get these` \
   CC="`gnustep-config --variable=CC`" \
   CPP="`gnustep-config --variable=CPP`" \
@@ -31,7 +31,7 @@ echo "### Running configure"
 
 echo
 echo "### Building"
-make -j "${BUILD_THREADS:-`nproc`}"
+make -j "${BUILD_THREADS:-`nproc`}" || bash
 
 echo
 echo "### Installing"


### PR DESCRIPTION
Not actually too much needed to change here, I ended up removing a lot of stuff from the old branch because it turned out those problems were caused by the toolchain issues that I resolved a few months ago by switching us to visual studio LLVM.

The big exception is ICU, which has a really weird build quirk that took _ages_ to figure out. It's not documented anywhere as far as I can tell, but [based on their github actions CI build script](https://github.com/unicode-org/icu/blob/06a23f8d37ce0c3a985bb676cbc05eb7bd5f3573/.github/workflows/icu4c.yml#L435), they do an x64 build *first* on arm before running the arm64 build. If you don't do this, you run into lots of cryptic errors.

The downside of this is that because ICU is one of the slowest parts of the build, this inflates the build times on ARM64 considerably.

I also added a .gitattributes file to resolve some cryptic errors caused by `.bat` scripts having LF line endings.