### PR TITLE
FAN-7783: Building libcurl with UNICODE defined

### DIFF
--- a/phases/19-libcurl.bat
+++ b/phases/19-libcurl.bat
@@ -33,6 +33,7 @@ cmake .. %CMAKE_OPTIONS% ^
   -D CURL_USE_SCHANNEL=YES ^
   -D CURL_ZLIB=ON ^
   -D BUILD_CURL_EXE=NO ^
+  -DCMAKE_C_FLAGS="-DUNICODE -D_UNICODE" ^
   || exit /b 1
 
 echo.


### PR DESCRIPTION
For NTLM, this allows usernames and password containing extended characters like 'á'.

See https://github.com/curl/curl/issues/2120 and https://github.com/curl/curl/blob/master/docs/KNOWN_BUGS#L272 (5.15 Unicode on Windows)